### PR TITLE
Fixed default[:mysql][:bind_address] for GCE

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,6 @@ default[:mysql_component][:schema][:dbname] = nil
 
 default[:mysql_component][:sql_url] = nil
 default[:mysql_component][:hosts] = ["localhost"]
+
+normal[:mysql][:bind_address] = '0.0.0.0'
+


### PR DESCRIPTION
For some kinds of clouds node[:cloud][:local_ipv4] will be not String, but Array. Pull request contains fix of this problem
